### PR TITLE
feat: add vanilla, paper, purpur, forge, neoforge and curseforge modpack minecraft templates

### DIFF
--- a/templates/minecraft/curseforge-modpack.yaml
+++ b/templates/minecraft/curseforge-modpack.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=../../schema/template.schema.json
+name: Minecraft CurseForge Modpack
+description: Minecraft server automatically installing a CurseForge modpack. Requires a free CurseForge API key.
+variables:
+  - name: Modpack Page URL
+    type: string
+    placeholder: modpack_url
+    example: 'https://www.curseforge.com/minecraft/modpacks/all-the-mods-10'
+    description: The CurseForge modpack page URL (e.g. https://www.curseforge.com/minecraft/modpacks/all-the-mods-10). See https://github.com/itzg/docker-minecraft-server/blob/master/docs/types-and-platforms/mod-platforms/auto-curseforge.md for all supported formats.
+  - name: CurseForge API Key
+    type: string
+    placeholder: cf_api_key
+    description: Your personal CurseForge API key, required to download modpack files. Get a free key at https://console.curseforge.com/
+  - name: Memory Allocation (in Gigabyte)
+    type: string
+    placeholder: memory
+    example: '8'
+    default: '8'
+    description: Amount of RAM in gigabytes allocated to the server JVM. Large modpacks typically need 6-12 GB.
+tags:
+  - curseforge
+  - modpack
+  - mods
+game_id: 38365
+docker_image_name: itzg/minecraft-server
+docker_image_tag: latest
+environment_variables:
+  EULA: 'true'
+  TYPE: 'AUTO_CURSEFORGE'
+  CF_PAGE_URL: '{{modpack_url}}'
+  CF_API_KEY: '{{cf_api_key}}'
+  MEMORY: '{{memory}}G'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data
+resource_limit:
+  memory: 8GiB
+  cpu: 4

--- a/templates/minecraft/curseforge-modpack.yaml
+++ b/templates/minecraft/curseforge-modpack.yaml
@@ -6,7 +6,7 @@ variables:
     type: string
     placeholder: modpack_url
     example: 'https://www.curseforge.com/minecraft/modpacks/all-the-mods-10'
-    description: The CurseForge modpack page URL (e.g. https://www.curseforge.com/minecraft/modpacks/all-the-mods-10). See https://github.com/itzg/docker-minecraft-server/blob/master/docs/types-and-platforms/mod-platforms/auto-curseforge.md for all supported formats.
+    description: The CurseForge modpack page URL. See https://github.com/itzg/docker-minecraft-server/blob/master/docs/types-and-platforms/mod-platforms/auto-curseforge.md for all supported formats.
   - name: CurseForge API Key
     type: string
     placeholder: cf_api_key

--- a/templates/minecraft/fabric-cosy-integration.yaml
+++ b/templates/minecraft/fabric-cosy-integration.yaml
@@ -7,7 +7,7 @@ variables:
     regex: \d\.\d+\.\d+
     placeholder: version
     example: '1.21.2'
-    description: The Minecraft version to run (e.g. 1.21.2)
+    description: The Minecraft version to run
   - name: Memory Allocation (in Gigabyte)
     type: string
     placeholder: memory

--- a/templates/minecraft/fabric.yaml
+++ b/templates/minecraft/fabric.yaml
@@ -7,7 +7,7 @@ variables:
     regex: \d\.\d+\.\d+
     placeholder: version
     example: '1.21.2'
-    description: The Minecraft version to run (e.g. 1.21.2)
+    description: The Minecraft version to run
   - name: Memory Allocation (in Gigabyte)
     type: string
     placeholder: memory

--- a/templates/minecraft/forge.yaml
+++ b/templates/minecraft/forge.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schema/template.schema.json
+name: Minecraft Forge
+description: Minecraft Forge mod loader server - the classic modding platform. Place mods in /data/mods.
+variables:
+  - name: Minecraft Version
+    type: string
+    regex: \d\.\d+\.\d+
+    placeholder: version
+    example: '1.20.1'
+    description: The Minecraft version to run. Most Forge mods target 1.20.1 or 1.12.2. See https://files.minecraftforge.net/ for available versions.
+  - name: Memory Allocation (in Gigabyte)
+    type: string
+    placeholder: memory
+    example: '6'
+    default: '6'
+    description: Amount of RAM in gigabytes allocated to the server JVM. Modded servers typically need 4-8 GB depending on mod count.
+tags:
+  - forge
+  - mods
+game_id: 38365
+docker_image_name: itzg/minecraft-server
+docker_image_tag: latest
+environment_variables:
+  VERSION: '{{version}}'
+  EULA: 'true'
+  TYPE: 'FORGE'
+  MEMORY: '{{memory}}G'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data
+resource_limit:
+  memory: 6GiB
+  cpu: 3

--- a/templates/minecraft/neoforge.yaml
+++ b/templates/minecraft/neoforge.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schema/template.schema.json
+name: Minecraft NeoForge
+description: Minecraft NeoForge mod loader server - the modern successor to Forge for 1.20.2 and newer. Place mods in /data/mods.
+variables:
+  - name: Minecraft Version
+    type: string
+    regex: \d\.\d+\.\d+
+    placeholder: version
+    example: '1.21.5'
+    description: The Minecraft version to run. NeoForge supports 1.20.2 and newer only. See https://neoforged.net/ for supported versions.
+  - name: Memory Allocation (in Gigabyte)
+    type: string
+    placeholder: memory
+    example: '6'
+    default: '6'
+    description: Amount of RAM in gigabytes allocated to the server JVM. Modded servers typically need 4-8 GB depending on mod count.
+tags:
+  - neoforge
+  - mods
+game_id: 38365
+docker_image_name: itzg/minecraft-server
+docker_image_tag: latest
+environment_variables:
+  VERSION: '{{version}}'
+  EULA: 'true'
+  TYPE: 'NEOFORGE'
+  MEMORY: '{{memory}}G'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data
+resource_limit:
+  memory: 6GiB
+  cpu: 3

--- a/templates/minecraft/paper.yaml
+++ b/templates/minecraft/paper.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schema/template.schema.json
+name: Minecraft Paper
+description: High-performance Paper server with Bukkit/Spigot plugin support. Drop-in vanilla replacement with significant performance improvements.
+variables:
+  - name: Minecraft Version
+    type: string
+    regex: \d\.\d+\.\d+
+    placeholder: version
+    example: '1.21.5'
+    description: The Minecraft version to run (e.g. 1.21.5). See https://papermc.io/downloads/paper for supported versions.
+  - name: Memory Allocation (in Gigabyte)
+    type: string
+    placeholder: memory
+    example: '4'
+    default: '4'
+    description: Amount of RAM in gigabytes allocated to the server JVM. Plugin servers typically benefit from at least 4 GB.
+tags:
+  - paper
+  - plugins
+game_id: 38365
+docker_image_name: itzg/minecraft-server
+docker_image_tag: latest
+environment_variables:
+  VERSION: '{{version}}'
+  EULA: 'true'
+  TYPE: 'PAPER'
+  MEMORY: '{{memory}}G'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data
+resource_limit:
+  memory: 4GiB
+  cpu: 2

--- a/templates/minecraft/paper.yaml
+++ b/templates/minecraft/paper.yaml
@@ -7,7 +7,7 @@ variables:
     regex: \d\.\d+\.\d+
     placeholder: version
     example: '1.21.5'
-    description: The Minecraft version to run (e.g. 1.21.5). See https://papermc.io/downloads/paper for supported versions.
+    description: The Minecraft version to run. See https://papermc.io/downloads/paper for supported versions.
   - name: Memory Allocation (in Gigabyte)
     type: string
     placeholder: memory

--- a/templates/minecraft/purpur.yaml
+++ b/templates/minecraft/purpur.yaml
@@ -7,7 +7,7 @@ variables:
     regex: \d\.\d+\.\d+
     placeholder: version
     example: '1.21.5'
-    description: The Minecraft version to run (e.g. 1.21.5). See https://purpurmc.org/downloads for supported versions.
+    description: The Minecraft version to run. See https://purpurmc.org/downloads for supported versions.
   - name: Memory Allocation (in Gigabyte)
     type: string
     placeholder: memory

--- a/templates/minecraft/purpur.yaml
+++ b/templates/minecraft/purpur.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schema/template.schema.json
+name: Minecraft Purpur
+description: Purpur server - a Paper fork with extra performance tuning and highly configurable gameplay options. Supports Bukkit/Spigot/Paper plugins.
+variables:
+  - name: Minecraft Version
+    type: string
+    regex: \d\.\d+\.\d+
+    placeholder: version
+    example: '1.21.5'
+    description: The Minecraft version to run (e.g. 1.21.5). See https://purpurmc.org/downloads for supported versions.
+  - name: Memory Allocation (in Gigabyte)
+    type: string
+    placeholder: memory
+    example: '4'
+    default: '4'
+    description: Amount of RAM in gigabytes allocated to the server JVM
+tags:
+  - purpur
+  - plugins
+game_id: 38365
+docker_image_name: itzg/minecraft-server
+docker_image_tag: latest
+environment_variables:
+  VERSION: '{{version}}'
+  EULA: 'true'
+  TYPE: 'PURPUR'
+  MEMORY: '{{memory}}G'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data
+resource_limit:
+  memory: 4GiB
+  cpu: 2

--- a/templates/minecraft/vanilla.yaml
+++ b/templates/minecraft/vanilla.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=../../schema/template.schema.json
+name: Minecraft Vanilla
+description: Plain vanilla Minecraft server using the official Mojang server jar
+variables:
+  - name: Minecraft Version
+    type: string
+    regex: \d\.\d+\.\d+
+    placeholder: version
+    example: '1.21.5'
+    description: The Minecraft version to run (e.g. 1.21.5). See https://www.minecraft.net/en-us/article/minecraft-java-edition for the latest release.
+  - name: Memory Allocation (in Gigabyte)
+    type: string
+    placeholder: memory
+    example: '2'
+    default: '2'
+    description: Amount of RAM in gigabytes allocated to the server JVM
+tags:
+  - vanilla
+game_id: 38365
+docker_image_name: itzg/minecraft-server
+docker_image_tag: latest
+environment_variables:
+  VERSION: '{{version}}'
+  EULA: 'true'
+  TYPE: 'VANILLA'
+  MEMORY: '{{memory}}G'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data
+resource_limit:
+  memory: 2GiB
+  cpu: 2

--- a/templates/minecraft/vanilla.yaml
+++ b/templates/minecraft/vanilla.yaml
@@ -7,7 +7,7 @@ variables:
     regex: \d\.\d+\.\d+
     placeholder: version
     example: '1.21.5'
-    description: The Minecraft version to run (e.g. 1.21.5). See https://www.minecraft.net/en-us/article/minecraft-java-edition for the latest release.
+    description: The Minecraft version to run. See https://www.minecraft.net/en-us/article/minecraft-java-edition for the latest release.
   - name: Memory Allocation (in Gigabyte)
     type: string
     placeholder: memory


### PR DESCRIPTION
## Summary

- Adds 6 new Minecraft server templates using the `itzg/minecraft-server` image
- **Vanilla** – plain Mojang server jar
- **Paper** – high-performance Bukkit/Spigot plugin server
- **Purpur** – Paper fork with extra configurability, also supports plugins
- **Forge** – classic mod loader (example targets 1.20.1, the most popular Forge version)
- **NeoForge** – modern Forge successor for 1.20.2+
- **CurseForge Modpack** – auto-installs any CurseForge modpack via `AUTO_CURSEFORGE` (requires a free CF API key)

## Test plan

- [ ] CI schema validation passes for all 6 new templates
- [ ] Each template loads correctly in the Cosy frontend game server creation flow
- [ ] Variable descriptions with links render correctly (auto-link detection)
- [ ] CurseForge modpack template successfully installs a modpack end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)