### PR TITLE
feat: games YAML migration + template schema (host_mounts, annotations)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,9 +16,10 @@
 - [ ] The template file is placed at `templates/{game-name}/{template-description}.yaml`.
 - [ ] The template passes schema validation (`template.schema.json`) locally or in CI.
 - [ ] `name`, `description`, `game_id`, `docker_image_name`, and `docker_image_tag` are set.
+- [ ] `game_id` is a slug matching an existing `games/{slug}.yaml` — or a new `games/{slug}.yaml` is included in this PR.
 - [ ] All ports in `port_mapping` are valid (1–65535) and documented if non-standard.
 - [ ] Environment variables are documented or obvious (e.g. `version`, `MEMORY`, etc.).
-- [ ] `file_downloads` URLs are reachable and use versions/placeholders correctly.
+- [ ] `file_mounts` paths are absolute and point to the correct persistent-data directories.
 
 ## Testing
 

--- a/.github/workflows/validate-templates.yml
+++ b/.github/workflows/validate-templates.yml
@@ -12,4 +12,9 @@ jobs:
         with:
           file: 'templates/**/*.yaml'
           schema: 'schema/template.schema.json'
+      - name: Validate game definitions
+        uses: cardinalby/schema-validator-action@v3
+        with:
+          file: 'games/**/*.yaml'
+          schema: 'schema/game.schema.json'
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,55 @@ description: Minecraft Fabric Server with default fabric installation
 variables:
   - name: Minecraft Version
     type: string
-    regex: \d\.\d+\.\d
+    regex: \d\.\d+\.\d+
     placeholder: version
-game_id: '[steam_grid_db_game_id]' # This id comes from the https://www.steamgriddb.com/
+    example: '1.21.5'
+game_id: minecraft          # slug from games/minecraft.yaml
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
-# ... port_mapping, environment_variables, etc.
+environment_variables:
+  VERSION: '{{version}}'
+  EULA: 'true'
+port_mapping:
+  '25565/tcp': 25565
+file_mounts:
+  - /data                   # cosy-managed persistent volume
+resource_limit:
+  memory: 4GiB
+  cpu: 2
 ```
 
 **Full schema**: [schema/template.schema.json](schema/template.schema.json)
+
+## Games directory
+
+Every template's `game_id` references a slug — the filename (without `.yaml`) of an entry under [`games/`](games/). Each game file carries the display name and artwork URLs used in the Cosy UI:
+
+```yaml
+# games/minecraft.yaml
+name: Minecraft
+logo_url: https://cdn2.steamgriddb.com/logo/...
+hero_url: https://cdn2.steamgriddb.com/hero/...
+external_game_id: 38365    # legacy SteamGridDB id; omit for new games
+```
+
+When adding a template for a game that isn't listed yet, add a matching `games/{slug}.yaml` in the same PR.
+
+## Advanced fields
+
+Templates may also include:
+
+- **`annotations`** — Docker container labels applied at launch (all users). Values may contain `{{var}}` placeholders.
+- **`host_mounts`** — direct host-path bind mounts (`host_path → container_path`, optional `read_only`). Enforced admin-only at runtime.
+
+```yaml
+annotations:
+  traefik.enable: 'true'
+host_mounts:
+  - host_path: /var/run/docker.sock
+    container_path: /var/run/docker.sock
+    read_only: true
+```
 
 ## Contributing
 

--- a/games/ark.yaml
+++ b/games/ark.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../schema/game.schema.json
+name: "ARK: Survival Evolved"
+logo_url: https://cdn2.steamgriddb.com/logo/68e3bf852693ad8a72f32fdfe50dc6d4.png
+hero_url: https://cdn2.steamgriddb.com/hero/5c469784eafc2ded9338dedda197db25.png
+external_game_id: 6511

--- a/games/ark.yaml
+++ b/games/ark.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../schema/game.schema.json
 name: "ARK: Survival Evolved"
-logo_url: https://cdn2.steamgriddb.com/logo/68e3bf852693ad8a72f32fdfe50dc6d4.png
+logo_url: https://cdn2.steamgriddb.com/icon/3ec0e2c7f4536e7ce9e9ce183b1de9e8/32/256x256.png
 hero_url: https://cdn2.steamgriddb.com/hero/5c469784eafc2ded9338dedda197db25.png
 external_game_id: 6511

--- a/games/cs2.yaml
+++ b/games/cs2.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../schema/game.schema.json
+name: Counter-Strike 2
+logo_url: https://cdn2.steamgriddb.com/logo/3120e046c5cd9433ceb52aa1433810c8.png
+hero_url: https://cdn2.steamgriddb.com/hero/2b1ec9ecde3fcfa54840a68765c3f647.png
+external_game_id: 5363838

--- a/games/cs2.yaml
+++ b/games/cs2.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../schema/game.schema.json
 name: Counter-Strike 2
-logo_url: https://cdn2.steamgriddb.com/logo/3120e046c5cd9433ceb52aa1433810c8.png
+logo_url: https://cdn2.steamgriddb.com/icon/e1bd06c3f8089e7552aa0552cb387c92/32/256x256.png
 hero_url: https://cdn2.steamgriddb.com/hero/2b1ec9ecde3fcfa54840a68765c3f647.png
 external_game_id: 5363838

--- a/games/minecraft.yaml
+++ b/games/minecraft.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../schema/game.schema.json
 name: Minecraft
-logo_url: https://cdn2.steamgriddb.com/logo/90915208c601cc8c86ad01250ee90c12.png
+logo_url: https://cdn2.steamgriddb.com/icon/add7a048049671970976f3e18f21ade3/32/256x256.png
 hero_url: https://cdn2.steamgriddb.com/hero/ecd812da02543c0269cfc2c56ab3c3c0.png
 external_game_id: 38365

--- a/games/minecraft.yaml
+++ b/games/minecraft.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../schema/game.schema.json
+name: Minecraft
+logo_url: https://cdn2.steamgriddb.com/logo/90915208c601cc8c86ad01250ee90c12.png
+hero_url: https://cdn2.steamgriddb.com/hero/ecd812da02543c0269cfc2c56ab3c3c0.png
+external_game_id: 38365

--- a/games/palworld.yaml
+++ b/games/palworld.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../schema/game.schema.json
+name: Palworld
+logo_url: https://cdn2.steamgriddb.com/logo/adb65ff91470f0f4cab8c6bdfc8e7acc.png
+hero_url: https://cdn2.steamgriddb.com/hero/b12d24919e9df602efa0a0af9d99eb32.jpg
+external_game_id: 5286879

--- a/games/palworld.yaml
+++ b/games/palworld.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../schema/game.schema.json
 name: Palworld
-logo_url: https://cdn2.steamgriddb.com/logo/adb65ff91470f0f4cab8c6bdfc8e7acc.png
+logo_url: https://cdn2.steamgriddb.com/icon/82cf0712367108660c5339a4897a728e/32/256x256.png
 hero_url: https://cdn2.steamgriddb.com/hero/b12d24919e9df602efa0a0af9d99eb32.jpg
 external_game_id: 5286879

--- a/games/terraria.yaml
+++ b/games/terraria.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../schema/game.schema.json
 name: Terraria
-logo_url: https://cdn2.steamgriddb.com/logo/af922fd52975aee0083fb8e0ba9c1d64.png
+logo_url: https://cdn2.steamgriddb.com/icon/c8157144d45faf12c01a459170b2333a/32/256x256.png
 hero_url: https://cdn2.steamgriddb.com/hero/32e8e6c03f3fa46eb672dc5680bff7da.png
 external_game_id: 1226

--- a/games/terraria.yaml
+++ b/games/terraria.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../schema/game.schema.json
+name: Terraria
+logo_url: https://cdn2.steamgriddb.com/logo/af922fd52975aee0083fb8e0ba9c1d64.png
+hero_url: https://cdn2.steamgriddb.com/hero/32e8e6c03f3fa46eb672dc5680bff7da.png
+external_game_id: 1226

--- a/schema/game.schema.json
+++ b/schema/game.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Magenta-Mause/Cosy-Templates/schema/game.schema.json",
+  "title": "Game",
+  "description": "Schema for a game definition. The file name (its slug, without the .yaml extension) is the identifier templates reference via their game_id field.",
+  "type": "object",
+  "required": ["name"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "Human-readable display name of the game (e.g. 'Minecraft', 'Counter-Strike 2')"
+    },
+    "logo_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Optional URL to the game's logo artwork (SteamGridDB CDN URL carried over from the legacy game-service)"
+    },
+    "hero_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Optional URL to the game's hero/banner artwork (SteamGridDB CDN URL carried over from the legacy game-service)"
+    },
+    "external_game_id": {
+      "type": "integer",
+      "description": "Optional SteamGridDB numeric game id. Single source of truth for the legacy numeric id; used to resolve templates whose game_id is still numeric."
+    }
+  }
+}

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -46,6 +46,10 @@
         "example": {
           "type": "string",
           "description": "Example value to display for free text inputs (e.g., '1.21.2' for a version field)"
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether the variable must be provided by the user (no default accepted)"
         }
       }
     },

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Magenta-Mause/Cosy-Templates/schema/template.schema.json",
   "title": "Game Server Template",
-  "description": "Schema for game server deployment templates usable in cosy",
+  "description": "Schema for game server deployment templates usable in cosy. Fields may carry {{var}} placeholder strings, and host_mounts + annotations are supported.",
   "$defs": {
     "Variable": {
       "type": "object",
@@ -54,18 +54,55 @@
       "additionalProperties": false,
       "properties": {
         "memory": {
-          "type": "string",
-          "pattern": "^[0-9]+(\\.[0-9]+)?(MiB|GiB)?$",
-          "description": "Memory limit (e.g., '128MiB', '1GiB', '512MiB')"
+          "description": "Memory limit (e.g., '128MiB', '1GiB', '512MiB'). May be a {{var}} placeholder string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(MiB|GiB)?$"
+            },
+            {
+              "type": "string",
+              "pattern": "\\{\\{[a-z_][a-z0-9_]*\\}\\}"
+            }
+          ]
         },
         "cpu": {
-          "type": "number",
-          "minimum": 0.01,
-          "maximum": 128,
-          "description": "CPU limit in cores (e.g., 0.5 = half core, 2 = two cores)"
+          "description": "CPU limit in cores (e.g., 0.5 = half core, 2 = two cores). May be a {{var}} placeholder string.",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0.01,
+              "maximum": 128
+            },
+            {
+              "type": "string"
+            }
+          ]
         }
       },
       "description": "Container resource limits"
+    },
+    "HostMount": {
+      "type": "object",
+      "required": ["host_path", "container_path"],
+      "additionalProperties": false,
+      "properties": {
+        "host_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path on the Docker host to bind mount (e.g. '/var/run/docker.sock'). May contain {{var}} placeholders."
+        },
+        "container_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute path inside the container where the host path is mounted. May contain {{var}} placeholders."
+        },
+        "read_only": {
+          "type": "boolean",
+          "description": "Whether the bind mount is read-only. Defaults to true when omitted."
+        }
+      },
+      "description": "A direct host volume bind mount (admin/owner only at runtime)."
     }
   },
   "type": "object",
@@ -98,8 +135,8 @@
       }
     },
     "game_id": {
-      "type": "number",
-      "description": "Unique game identifier (SteamGridDB ID or slug)"
+      "type": ["string", "number"],
+      "description": "Game reference: a game slug (the games/*.yaml filename without extension) or a legacy SteamGridDB numeric id."
     },
     "docker_image_name": {
       "type": "string",
@@ -135,12 +172,11 @@
             "maximum": 65535
           },
           {
-            "type": "string",
-            "enum": ["tcp", "udp"]
+            "type": "string"
           }
         ]
       },
-      "description": "Port mappings as 'host_port': container_port or 'host_port/protocol': container_port"
+      "description": "Port mappings as 'host_port': container_port or 'host_port/protocol': container_port. Values may be integers or {{var}} placeholder strings."
     },
     "file_mounts": {
       "type": "array",
@@ -148,7 +184,21 @@
         "type": "string",
         "pattern": "^/.*$"
       },
-      "description": "Paths inside the container to mount as persistent volumes"
+      "description": "Paths inside the container to mount as cosy-managed persistent volumes"
+    },
+    "host_mounts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/HostMount"
+      },
+      "description": "Direct host volume bind mounts (explicit host_path -> container_path). Admin/owner only at runtime."
+    },
+    "annotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Docker container labels applied at launch. Keys and values are strings; values may contain {{var}} placeholders. Keys starting with the reserved prefix 'cosy.' are stripped at runtime."
     },
     "resource_limit": {
       "$ref": "#/$defs/ResourceLimit",

--- a/schema/template.schema.json
+++ b/schema/template.schema.json
@@ -54,7 +54,7 @@
       "additionalProperties": false,
       "properties": {
         "memory": {
-          "description": "Memory limit (e.g., '128MiB', '1GiB', '512MiB'). May be a {{var}} placeholder string.",
+          "description": "Memory limit. Either a concrete value (e.g. '128MiB', '1GiB', '512MiB') or any string containing a {{var}} placeholder (e.g. '{{memory}}', '{{memory}}GiB'). When a placeholder is used, the template author is responsible for documenting the expected value in the variable config; the resolved value is validated at runtime.",
           "oneOf": [
             {
               "type": "string",
@@ -62,7 +62,7 @@
             },
             {
               "type": "string",
-              "pattern": "\\{\\{[a-z_][a-z0-9_]*\\}\\}"
+              "pattern": "^.*\\{\\{[a-z_][a-z0-9_]*\\}\\}.*$"
             }
           ]
         },

--- a/templates/ark-survival-evolved/default.yaml
+++ b/templates/ark-survival-evolved/default.yaml
@@ -41,7 +41,7 @@ variables:
     description: Automatically create a backup of the world when the server stops
 tags:
   - survival
-game_id: 6511
+game_id: ark
 docker_image_name: hermsi/ark-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/cs2/default.yaml
+++ b/templates/cs2/default.yaml
@@ -9,7 +9,7 @@ variables:
     description: Steam Game Server Login Token (GSLT) required to list the server publicly on Steam. Get one at https://steamcommunity.com/dev/managegameservers
 tags:
   - competitive
-game_id: 5363838
+game_id: cs2
 docker_image_name: joedwards32/cs2
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/curseforge-modpack.yaml
+++ b/templates/minecraft/curseforge-modpack.yaml
@@ -21,7 +21,7 @@ tags:
   - curseforge
   - modpack
   - mods
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/fabric-cosy-integration.yaml
+++ b/templates/minecraft/fabric-cosy-integration.yaml
@@ -17,7 +17,7 @@ variables:
 tags:
   - fabric
   - cosy-integrated
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/fabric.yaml
+++ b/templates/minecraft/fabric.yaml
@@ -16,7 +16,7 @@ variables:
     description: Amount of RAM in gigabytes allocated to the server JVM
 tags:
   - fabric
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/forge.yaml
+++ b/templates/minecraft/forge.yaml
@@ -17,7 +17,7 @@ variables:
 tags:
   - forge
   - mods
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/modrinth-modpack.yaml
+++ b/templates/minecraft/modrinth-modpack.yaml
@@ -16,7 +16,7 @@ variables:
 tags:
   - fabric
   - modpack
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/neoforge.yaml
+++ b/templates/minecraft/neoforge.yaml
@@ -17,7 +17,7 @@ variables:
 tags:
   - neoforge
   - mods
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/paper.yaml
+++ b/templates/minecraft/paper.yaml
@@ -17,7 +17,7 @@ variables:
 tags:
   - paper
   - plugins
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/purpur.yaml
+++ b/templates/minecraft/purpur.yaml
@@ -17,7 +17,7 @@ variables:
 tags:
   - purpur
   - plugins
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/minecraft/vanilla.yaml
+++ b/templates/minecraft/vanilla.yaml
@@ -16,7 +16,7 @@ variables:
     description: Amount of RAM in gigabytes allocated to the server JVM
 tags:
   - vanilla
-game_id: 38365
+game_id: minecraft
 docker_image_name: itzg/minecraft-server
 docker_image_tag: latest
 environment_variables:

--- a/templates/palworld/default.yaml
+++ b/templates/palworld/default.yaml
@@ -30,7 +30,7 @@ variables:
     description: Short description shown in the server browser
 tags:
   - survival
-game_id: 5286879
+game_id: palworld
 docker_image_name: thijsvanloef/palworld-server-docker
 docker_image_tag: latest
 environment_variables:

--- a/templates/terraria/vanilla.yaml
+++ b/templates/terraria/vanilla.yaml
@@ -31,7 +31,7 @@ variables:
 tags:
   - survival
   - vanilla
-game_id: 1226
+game_id: terraria
 docker_image_name: hexlo/terraria-server-docker
 docker_image_tag: latest
 environment_variables:


### PR DESCRIPTION
## What
Phase 0 of the host-mounts / annotations / template-schema / games-migration effort.

- **Games migrated to YAML** under `games/` (one file per game: `name`, `logo_url`, `hero_url`, `external_game_id`), replacing the SteamGridDB numeric reference. Seeded: minecraft, cs2, palworld, ark, terraria. Artwork URLs sourced from the live game-api and HEAD-verified 200.
- **`schema/game.schema.json`** added.
- **`schema/template.schema.json` extended** — this is the single authoring schema; it validates the template **files**, not the API output. `game_id` and `resource_limit`/`port` values now accept string-or-number (to carry `{{var}}`), plus new `annotations` (map) and `host_mounts` (`host_path`/`container_path`/`read_only`) fields.
- **All 13 templates migrated** from numeric `game_id` → game slug (backward-compatible: numeric ids still resolve via fallback in the backend and v1/v2 endpoints).
- CI now also validates `games/**`.

## Validation
ajv (draft 2020-12): 13 templates + 5 games pass.

Refs Magenta-Mause/Cosy#70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
