### PR TITLE
feat(templates): wire {{memory}} variable to resource_limit.memory in Minecraft templates

### DIFF
--- a/templates/minecraft/curseforge-modpack.yaml
+++ b/templates/minecraft/curseforge-modpack.yaml
@@ -35,5 +35,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 8GiB
+  memory: '{{memory}}GiB'
   cpu: 4

--- a/templates/minecraft/fabric-cosy-integration.yaml
+++ b/templates/minecraft/fabric-cosy-integration.yaml
@@ -31,5 +31,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 6GiB
+  memory: '{{memory}}GiB'
   cpu: 3

--- a/templates/minecraft/fabric.yaml
+++ b/templates/minecraft/fabric.yaml
@@ -30,5 +30,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 6GiB
+  memory: '{{memory}}GiB'
   cpu: 3

--- a/templates/minecraft/forge.yaml
+++ b/templates/minecraft/forge.yaml
@@ -30,5 +30,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 6GiB
+  memory: '{{memory}}GiB'
   cpu: 3

--- a/templates/minecraft/modrinth-modpack.yaml
+++ b/templates/minecraft/modrinth-modpack.yaml
@@ -30,6 +30,6 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 6GiB
+  memory: '{{memory}}GiB'
   cpu: 3
 

--- a/templates/minecraft/neoforge.yaml
+++ b/templates/minecraft/neoforge.yaml
@@ -30,5 +30,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 6GiB
+  memory: '{{memory}}GiB'
   cpu: 3

--- a/templates/minecraft/paper.yaml
+++ b/templates/minecraft/paper.yaml
@@ -30,5 +30,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 4GiB
+  memory: '{{memory}}GiB'
   cpu: 2

--- a/templates/minecraft/purpur.yaml
+++ b/templates/minecraft/purpur.yaml
@@ -30,5 +30,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 4GiB
+  memory: '{{memory}}GiB'
   cpu: 2

--- a/templates/minecraft/vanilla.yaml
+++ b/templates/minecraft/vanilla.yaml
@@ -29,5 +29,5 @@ port_mapping:
 file_mounts:
   - /data
 resource_limit:
-  memory: 2GiB
+  memory: '{{memory}}GiB'
   cpu: 2


### PR DESCRIPTION
## Summary

- All 9 Minecraft templates previously had a user-facing `memory` variable that only fed the JVM heap env var (`MEMORY: '{{memory}}G'`) while `resource_limit.memory` remained a hardcoded static value (e.g. `4GiB`, `6GiB`).
- This change sets `resource_limit.memory: '{{memory}}GiB'` in all 9 templates so the Docker container memory cap is driven by the same user-supplied value, keeping the two in sync.
- Non-Minecraft templates (ARK, CS2, Palworld, Terraria) have no memory variable and are unchanged.

## Affected templates

- `minecraft/vanilla.yaml`
- `minecraft/paper.yaml`
- `minecraft/purpur.yaml`
- `minecraft/fabric.yaml`
- `minecraft/fabric-cosy-integration.yaml`
- `minecraft/forge.yaml`
- `minecraft/neoforge.yaml`
- `minecraft/modrinth-modpack.yaml`
- `minecraft/curseforge-modpack.yaml`

## Test plan

- [ ] AJV schema validation passes for all templates (`{{memory}}GiB` is a valid string value for `resource_limit.memory` per the v3 schema)
- [ ] Frontend substitution replaces `{{memory}}` with the user-entered value before sending to the backend
- [ ] A server created with memory=4 gets a 4 GiB container limit and a 4 G JVM heap

🤖 Generated with [Claude Code](https://claude.com/claude-code)